### PR TITLE
Add Docker setup and configurable admin list

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.dist-info/
+.env
+.env.*
+.git
+.gitignore

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in your real Telegram bot token
+BOT_TOKEN=123456:PUT_YOUR_BOT_TOKEN_HERE
+# Optional: comma-separated list of Telegram user IDs that can run admin commands
+ADMINS=123456789
+# Optional: change logging level (DEBUG, INFO, WARNING...)
+LOG_LEVEL=INFO

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+CMD ["python", "moderator_bot.py"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
 # TotalModBot
+
+TotalModBot is a simple Telegram moderation bot that lets trusted admins manage a shared ban list across multiple groups. It uses long polling via `python-telegram-bot` v20.
+
+## Prerequisites
+
+- A Telegram bot token from [BotFather](https://core.telegram.org/bots#botfather).
+- Docker Desktop for Windows 10/11 Pro with the WSL2 backend enabled.
+
+## Quick start (Docker)
+
+1. **Clone** or download this repository to your PC.
+2. **Copy** the example environment file and add your real values:
+   ```powershell
+   Copy-Item .env.example .env
+   ```
+   Edit `.env` in your preferred editor and set:
+   - `BOT_TOKEN` to the token you received from BotFather.
+   - `ADMINS` to a comma- or semicolon-separated list of Telegram user IDs that can run moderator commands.
+   - Optionally tweak `LOG_LEVEL` (INFO, DEBUG, WARNING, ...).
+3. **Build and start** the container from a PowerShell or Windows Terminal window opened inside the project directory:
+   ```powershell
+   docker compose up --build -d
+   ```
+   The bot will start in the background and connect to Telegram using long polling.
+4. **Check the logs** to verify the bot started successfully:
+   ```powershell
+   docker compose logs -f
+   ```
+5. **Stop** the bot when you are done:
+   ```powershell
+   docker compose down
+   ```
+
+### Persistent data
+
+The container stores moderation data (managed chat IDs and global bans) inside a named Docker volume (`bot_data`). The data persists across restarts and container rebuilds. To remove it completely, run `docker compose down --volumes`.
+
+## Configuration options
+
+You can override the following environment variables in `.env` or when starting the container:
+
+| Variable    | Description |
+|-------------|-------------|
+| `BOT_TOKEN` | **Required.** Telegram bot token from BotFather. |
+| `ADMINS`    | Optional. Comma/semicolon separated list of Telegram user IDs allowed to run admin commands. Defaults to `123456789`. |
+| `LOG_LEVEL` | Optional. Python logging level (e.g. `INFO`, `DEBUG`). Defaults to `INFO`. |
+| `DATA_DIR`  | Optional. Directory for persistent JSON state inside the container. Defaults to `/app/data`. |
+| `DATA_FILE` | Optional. Custom JSON file path for persistent state. Defaults to `<DATA_DIR>/mod_data.json`. |
+
+## Development without Docker (optional)
+
+If you prefer running the bot directly on your machine:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
+$env:BOT_TOKEN = "123456:YOUR_TOKEN"
+python moderator_bot.py
+```
+
+Remember to keep your bot token private.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  moderator-bot:
+    build: .
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      - DATA_DIR=/app/data
+    volumes:
+      - bot_data:/app/data
+
+volumes:
+  bot_data:

--- a/reqiurements.txt
+++ b/reqiurements.txt
@@ -1,1 +1,0 @@
-pip install python-telegram-bot==20.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot==20.*


### PR DESCRIPTION
## Summary
- add a Dockerfile, docker-compose definition, and example environment file for containerized deployment
- load admin IDs and other runtime settings from environment variables while logging the configured values
- document a Windows-friendly Docker workflow and cleanup requirements handling

## Testing
- python -m compileall moderator_bot.py

------
https://chatgpt.com/codex/tasks/task_e_68d1289121688322bd3aa71f45542546